### PR TITLE
fixed issue when attempting to launch Meld with ./Meld

### DIFF
--- a/osx/Meld
+++ b/osx/Meld
@@ -3,11 +3,7 @@
 EXEC="exec"
 
 name="`basename $0`"
-if [[ "$0" == `pwd`* ]] || [[ "$0" == "//"* ]]; then
-    full_path="$0"
-else
-    full_path="`pwd`/$0"
-fi
+full_path=$(cd ${0%/*} && echo $PWD/${0##*/})
 tmp=`dirname "$full_path"`
 tmp=`dirname "$tmp"`
 bundle=`dirname "$tmp"`


### PR DESCRIPTION
Usage where launching Meld was broken involved the full_path variable calculation. Adjusted this to use a more explicit way (after some googling).
```
$ ./Meld
/Applications/Meld.app/Contents/Contents/Resources/lib:/Applications/Meld.app/Contents/Contents/Frameworks
./Meld: line 86: /Applications/Meld.app/Contents/Contents/MacOS/Meld-bin: No such file or directory
./Meld: line 86: exec: /Applications/Meld.app/Contents/Contents/MacOS/Meld-bin: cannot execute: No such file or directory
$ cd /
```