### PR TITLE
build_env: Automatically get the jhbuild Python site_packages path.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check System
         run: |

--- a/osx/build_env.sh
+++ b/osx/build_env.sh
@@ -44,10 +44,12 @@ export PKG_CONFIG_PATH=$HOME/gtk/inst/lib/pkgconfig:$HOME/gtk/inst/share/pkgconf
 export XDG_DATA_DIRS=$HOME/gtk/inst/share
 jhbuild buildone libffi python3 libxml2
 (cd $HOME/gtk/inst/bin && touch itstool && chmod +x itstool)
-/usr/local/bin/pip3 install six pygments --target ~/gtk/inst/lib/python3.9/site-packages
+
+PY_SITE_PACKAGES=$(~/gtk/inst/bin/python3 -c 'import site; print(site.getsitepackages()[0], end="")')
+/usr/local/bin/pip3 install six pygments --target $PY_SITE_PACKAGES
 
 PYTHON=$HOME/gtk/inst/bin/python3 jhbuild build --nodeps --ignore-suggests #-s freetype-no-harfbuzz
-/usr/local/bin/pip3 install pyobjc-core pyobjc-framework-Cocoa py2app --target ~/gtk/inst/lib/python3.9/site-packages
+/usr/local/bin/pip3 install pyobjc-core pyobjc-framework-Cocoa py2app --target $PY_SITE_PACKAGES
 
 # (cd $HOME/gtk/inst/lib && ln -s libpython3.6m.dylib libpython3.6.dylib)
 # (cd $HOME/Source/ && ([ -d Mojave-gtk-theme ] || git clone https://github.com/vinceliuice/Mojave-gtk-theme.git))


### PR DESCRIPTION
So that it doesn't need to be manually updated in the shell script. If the Python version or path changes this should still provide the right site_packages path.

I tried to give building this a go, but it fails at the compiling cairo step which I'm not sure how to fix.
Hopefully this PR at least saves you a few minutes to fix the `pip install` step, as `jhbuild` fetches and builds Python 3.10 now and the `--taget ~/gtk/inst/lib/python3.9/site-packages` had to be updated.
